### PR TITLE
feat: template submit form page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,14 @@
 import { useState, useEffect } from 'react';
 import MainPage from './components/MainPage';
 import TemplatesPage from './components/TemplatesPage';
+import SubmitPage from './components/SubmitPage';
 
-type Page = 'home' | 'templates';
+type Page = 'home' | 'templates' | 'submit';
 
 function getPage(): Page {
-  return window.location.hash === '#templates' ? 'templates' : 'home';
+  if (window.location.hash === '#templates') return 'templates';
+  if (window.location.hash === '#submit') return 'submit';
+  return 'home';
 }
 
 export default function App() {
@@ -20,5 +23,7 @@ export default function App() {
     return () => window.removeEventListener('hashchange', handler);
   }, []);
 
-  return page === 'templates' ? <TemplatesPage /> : <MainPage />;
+  if (page === 'templates') return <TemplatesPage />;
+  if (page === 'submit') return <SubmitPage />;
+  return <MainPage />;
 }

--- a/src/components/SubmitPage.tsx
+++ b/src/components/SubmitPage.tsx
@@ -1,0 +1,239 @@
+import { useState } from 'react';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import styles from '../styles/SubmitPage.module.css';
+
+type Category = 'minimal' | 'dark' | 'creative' | 'tech';
+
+interface FormData {
+  name: string;
+  category: Category | '';
+  description: string;
+  previewUrl: string;
+  githubUrl: string;
+  author: string;
+  tags: string;
+}
+
+const CATEGORIES: { value: Category; label: string; desc: string }[] = [
+  { value: 'minimal', label: 'MINIMAL', desc: '깔끔하고 단순한 디자인' },
+  { value: 'dark', label: 'DARK', desc: '다크 테마 기반' },
+  { value: 'creative', label: 'CREATIVE', desc: '개성 있는 창의적 레이아웃' },
+  { value: 'tech', label: 'TECH', desc: '개발자 감성의 기술적 디자인' },
+];
+
+export default function SubmitPage() {
+  const [form, setForm] = useState<FormData>({
+    name: '',
+    category: '',
+    description: '',
+    previewUrl: '',
+    githubUrl: '',
+    author: '',
+    tags: '',
+  });
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitted(true);
+  };
+
+  const isValid = form.name && form.category && form.description && form.author;
+
+  if (submitted) {
+    return (
+      <div className={styles.page}>
+        <Navbar />
+        <div className={styles.successWrap}>
+          <div className={styles.successBox}>
+            <div className={styles.successIcon}>✓</div>
+            <h2 className={styles.successTitle}>제출 완료</h2>
+            <p className={styles.successDesc}>
+              템플릿이 성공적으로 제출되었습니다.<br />
+              검토 후 커뮤니티 갤러리에 등록됩니다.
+            </p>
+            <a href="#templates" className={styles.successLink}>템플릿 갤러리로 돌아가기 →</a>
+          </div>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.page}>
+      <Navbar />
+
+      {/* ── Header ── */}
+      <section className={styles.header}>
+        <div className={styles.headerInner}>
+          <p className={styles.headerLabel}>CONTRIBUTE</p>
+          <h1 className={styles.headerTitle}>SUBMIT<br />TEMPLATE</h1>
+          <p className={styles.headerSub}>
+            직접 만든 포트폴리오 템플릿을 커뮤니티와 공유하세요.
+          </p>
+        </div>
+        <div className={styles.headerSteps}>
+          <div className={styles.step}>
+            <div className={styles.stepNum}>01</div>
+            <div className={styles.stepText}>템플릿 정보 입력</div>
+          </div>
+          <div className={styles.stepArrow}>→</div>
+          <div className={styles.step}>
+            <div className={styles.stepNum}>02</div>
+            <div className={styles.stepText}>검토 (1-3일)</div>
+          </div>
+          <div className={styles.stepArrow}>→</div>
+          <div className={styles.step}>
+            <div className={styles.stepNum}>03</div>
+            <div className={styles.stepText}>갤러리 등록</div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Form ── */}
+      <div className={styles.formWrap}>
+        <form className={styles.form} onSubmit={handleSubmit}>
+
+          {/* 기본 정보 */}
+          <div className={styles.section}>
+            <h2 className={styles.sectionTitle}>기본 정보</h2>
+
+            <div className={styles.fieldRow}>
+              <div className={styles.field}>
+                <label className={styles.label}>
+                  템플릿 이름 <span className={styles.required}>*</span>
+                </label>
+                <input
+                  className={styles.input}
+                  name="name"
+                  value={form.name}
+                  onChange={handleChange}
+                  placeholder="예: Neo Brutalist"
+                  required
+                />
+              </div>
+              <div className={styles.field}>
+                <label className={styles.label}>
+                  작성자 / GitHub ID <span className={styles.required}>*</span>
+                </label>
+                <input
+                  className={styles.input}
+                  name="author"
+                  value={form.author}
+                  onChange={handleChange}
+                  placeholder="예: oh_minsu"
+                  required
+                />
+              </div>
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label}>
+                카테고리 <span className={styles.required}>*</span>
+              </label>
+              <div className={styles.categoryGrid}>
+                {CATEGORIES.map((cat) => (
+                  <button
+                    key={cat.value}
+                    type="button"
+                    className={`${styles.catCard} ${form.category === cat.value ? styles.catCardActive : ''}`}
+                    onClick={() => setForm((prev) => ({ ...prev, category: cat.value }))}
+                  >
+                    <div className={styles.catLabel}>{cat.label}</div>
+                    <div className={styles.catDesc}>{cat.desc}</div>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label}>
+                설명 <span className={styles.required}>*</span>
+              </label>
+              <textarea
+                className={styles.textarea}
+                name="description"
+                value={form.description}
+                onChange={handleChange}
+                placeholder="템플릿의 특징, 사용 대상, 디자인 컨셉을 설명해주세요."
+                rows={4}
+                required
+              />
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label}>태그</label>
+              <input
+                className={styles.input}
+                name="tags"
+                value={form.tags}
+                onChange={handleChange}
+                placeholder="예: React, TypeScript, Portfolio (쉼표로 구분)"
+              />
+              <p className={styles.hint}>검색 노출에 사용됩니다.</p>
+            </div>
+          </div>
+
+          {/* 링크 */}
+          <div className={styles.section}>
+            <h2 className={styles.sectionTitle}>링크</h2>
+
+            <div className={styles.fieldRow}>
+              <div className={styles.field}>
+                <label className={styles.label}>미리보기 URL</label>
+                <input
+                  className={styles.input}
+                  name="previewUrl"
+                  value={form.previewUrl}
+                  onChange={handleChange}
+                  placeholder="https://your-template-demo.vercel.app"
+                />
+              </div>
+              <div className={styles.field}>
+                <label className={styles.label}>GitHub 레포 URL</label>
+                <input
+                  className={styles.input}
+                  name="githubUrl"
+                  value={form.githubUrl}
+                  onChange={handleChange}
+                  placeholder="https://github.com/username/repo"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* 약관 */}
+          <div className={styles.section}>
+            <div className={styles.notice}>
+              <span className={styles.noticeIcon}>!</span>
+              <p className={styles.noticeText}>
+                제출된 템플릿은 buildme 커뮤니티 가이드라인 검토 후 등록됩니다.
+                오픈소스 라이선스를 준수해야 하며, 저작권을 침해하지 않아야 합니다.
+              </p>
+            </div>
+          </div>
+
+          <div className={styles.actions}>
+            <a href="#templates" className={styles.cancelBtn}>취소</a>
+            <button
+              type="submit"
+              className={`${styles.submitBtn} ${!isValid ? styles.submitBtnDisabled : ''}`}
+              disabled={!isValid}
+            >
+              템플릿 제출하기 →
+            </button>
+          </div>
+
+        </form>
+      </div>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/TemplatesPage.tsx
+++ b/src/components/TemplatesPage.tsx
@@ -225,10 +225,10 @@ export default function TemplatesPage() {
                 <div className={styles.statLabel}>CONTRIBUTORS</div>
               </div>
             </div>
-            <button className={styles.submitBtn}>
+            <a href="#submit" className={styles.submitBtn}>
               <PlusIcon />
               SUBMIT TEMPLATE
-            </button>
+            </a>
           </div>
         </div>
       </section>
@@ -306,7 +306,7 @@ export default function TemplatesPage() {
               다른 개발자들이 당신의 작업을 발전시킵니다.
             </p>
           </div>
-          <button className={styles.contributeCta}>SUBMIT YOUR TEMPLATE →</button>
+          <a href="#submit" className={styles.contributeCta}>SUBMIT YOUR TEMPLATE →</a>
         </div>
       </section>
 

--- a/src/styles/SubmitPage.module.css
+++ b/src/styles/SubmitPage.module.css
@@ -1,0 +1,413 @@
+.page {
+  background: #FAFAFA;
+  min-height: 100vh;
+}
+
+/* ── Header ── */
+.header {
+  background: var(--color-white);
+  border-bottom: 1px solid var(--color-gray-200);
+  padding: 120px 80px 56px;
+  max-width: 1400px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 40px;
+}
+
+.headerInner {
+  flex: 1;
+}
+
+.headerLabel {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 3px;
+  color: var(--color-gray-400);
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
+.headerTitle {
+  font-family: var(--font-display);
+  font-size: 80px;
+  line-height: 0.9;
+  color: var(--color-black);
+  letter-spacing: 1px;
+}
+
+.headerSub {
+  font-family: var(--font-heading);
+  font-size: 16px;
+  color: var(--color-gray-600);
+  margin-top: 20px;
+  line-height: 1.6;
+}
+
+/* Steps */
+.headerSteps {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-shrink: 0;
+}
+
+.step {
+  text-align: center;
+}
+
+.stepNum {
+  font-family: var(--font-display);
+  font-size: 28px;
+  color: var(--color-black);
+  line-height: 1;
+}
+
+.stepText {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--color-gray-400);
+  letter-spacing: 1px;
+  margin-top: 4px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.stepArrow {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--color-gray-200);
+}
+
+/* ── Form ── */
+.formWrap {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 64px 80px 100px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.section {
+  padding: 40px 0;
+  border-bottom: 1px solid var(--color-gray-200);
+}
+
+.section:last-of-type {
+  border-bottom: none;
+}
+
+.sectionTitle {
+  font-family: var(--font-display);
+  font-size: 28px;
+  color: var(--color-black);
+  margin-bottom: 28px;
+  letter-spacing: 1px;
+}
+
+/* Fields */
+.fieldRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.field:last-child {
+  margin-bottom: 0;
+}
+
+.label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 2px;
+  color: var(--color-black);
+  text-transform: uppercase;
+}
+
+.required {
+  color: #999;
+}
+
+.input {
+  padding: 14px 16px;
+  background: var(--color-white);
+  border: 1px solid var(--color-gray-200);
+  color: var(--color-black);
+  font-family: var(--font-heading);
+  font-size: 15px;
+  outline: none;
+  transition: border-color 0.2s;
+  border-radius: 0;
+  -webkit-appearance: none;
+}
+
+.input:focus {
+  border-color: var(--color-black);
+}
+
+.input::placeholder {
+  color: var(--color-gray-400);
+}
+
+.textarea {
+  padding: 14px 16px;
+  background: var(--color-white);
+  border: 1px solid var(--color-gray-200);
+  color: var(--color-black);
+  font-family: var(--font-heading);
+  font-size: 15px;
+  outline: none;
+  resize: vertical;
+  transition: border-color 0.2s;
+  line-height: 1.6;
+  border-radius: 0;
+}
+
+.textarea:focus {
+  border-color: var(--color-black);
+}
+
+.textarea::placeholder {
+  color: var(--color-gray-400);
+}
+
+.hint {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-gray-400);
+  letter-spacing: 1px;
+}
+
+/* Category Grid */
+.categoryGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+
+.catCard {
+  padding: 16px 12px;
+  background: var(--color-white);
+  border: 1px solid var(--color-gray-200);
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.15s;
+}
+
+.catCard:hover {
+  border-color: var(--color-black);
+}
+
+.catCardActive {
+  background: var(--color-black);
+  border-color: var(--color-black);
+}
+
+.catCardActive .catLabel {
+  color: var(--color-white);
+}
+
+.catCardActive .catDesc {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.catLabel {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 2px;
+  color: var(--color-black);
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+
+.catDesc {
+  font-family: var(--font-heading);
+  font-size: 11px;
+  color: var(--color-gray-400);
+  line-height: 1.4;
+}
+
+/* Notice */
+.notice {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  padding: 20px;
+  background: var(--color-gray-100);
+  border-left: 3px solid var(--color-black);
+}
+
+.noticeIcon {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--color-black);
+  font-weight: 700;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.noticeText {
+  font-family: var(--font-heading);
+  font-size: 13px;
+  color: var(--color-gray-600);
+  line-height: 1.6;
+}
+
+/* Actions */
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 16px;
+  padding-top: 40px;
+}
+
+.cancelBtn {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 1px;
+  color: var(--color-gray-400);
+  text-decoration: none;
+  padding: 16px 24px;
+  transition: color 0.2s;
+}
+
+.cancelBtn:hover {
+  color: var(--color-black);
+}
+
+.submitBtn {
+  padding: 16px 40px;
+  background: var(--color-black);
+  color: var(--color-white);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.2s;
+  text-transform: uppercase;
+}
+
+.submitBtn:hover:not(:disabled) {
+  background: #222;
+  transform: translateY(-2px);
+}
+
+.submitBtnDisabled {
+  background: var(--color-gray-200);
+  color: var(--color-gray-400);
+  cursor: not-allowed;
+}
+
+/* ── Success ── */
+.successWrap {
+  min-height: 70vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 80px;
+}
+
+.successBox {
+  text-align: center;
+  max-width: 440px;
+}
+
+.successIcon {
+  font-family: var(--font-mono);
+  font-size: 40px;
+  color: var(--color-black);
+  margin-bottom: 24px;
+  display: block;
+}
+
+.successTitle {
+  font-family: var(--font-display);
+  font-size: 48px;
+  color: var(--color-black);
+  margin-bottom: 16px;
+}
+
+.successDesc {
+  font-family: var(--font-heading);
+  font-size: 16px;
+  color: var(--color-gray-600);
+  line-height: 1.7;
+  margin-bottom: 32px;
+}
+
+.successLink {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 2px;
+  color: var(--color-black);
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  transition: opacity 0.2s;
+}
+
+.successLink:hover {
+  opacity: 0.6;
+}
+
+/* ── Responsive ── */
+@media (max-width: 1024px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 100px 40px 48px;
+  }
+
+  .headerSteps {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .formWrap {
+    padding: 48px 40px 80px;
+  }
+
+  .categoryGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .header {
+    padding: 90px 24px 40px;
+  }
+
+  .headerTitle {
+    font-size: 56px;
+  }
+
+  .headerSteps {
+    display: none;
+  }
+
+  .formWrap {
+    padding: 32px 24px 60px;
+  }
+
+  .fieldRow {
+    grid-template-columns: 1fr;
+  }
+
+  .categoryGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}


### PR DESCRIPTION
## Summary
- 템플릿 제출 폼 페이지(`SubmitPage`) 추가
- 이름, 카테고리, 설명, 태그, 미리보기/GitHub URL 입력 필드
- 필수 항목 미입력 시 제출 버튼 비활성화
- 제출 완료 후 success 상태 화면 표시
- `#submit` 해시 라우팅 추가
- TemplatesPage의 SUBMIT TEMPLATE 버튼 연결